### PR TITLE
Dev 对当导入大量标签且需要ai打标时只能开始导入并等待导入结束的逻辑感到不满，遂有此pr

### DIFF
--- a/apps/extension/components/ImportExportPage.tsx
+++ b/apps/extension/components/ImportExportPage.tsx
@@ -20,6 +20,7 @@ import {
   HelpCircle,
 } from "lucide-react";
 import {
+  Button,
   Card,
   CardContent,
   CardDescription,
@@ -69,6 +70,8 @@ export function ImportExportPage() {
     resumeWatchers,
   } = useBookmarks();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // 取消导入的信号 flag，由 handleCancelImport 置为 true
+  const cancelledRef = useRef(false);
   const {
     getBookmarks: getChromeBookmarks,
     loading: loadingBrowserBookmarks,
@@ -89,6 +92,7 @@ export function ImportExportPage() {
     message: string;
     details?: string;
     aiError?: { message: string };
+    cancelled?: boolean;
   } | null>(null);
 
   // 同步到浏览器状态 & 选项
@@ -190,6 +194,12 @@ export function ImportExportPage() {
     await exportData("html");
   };
 
+  // 取消正在进行的 HTML 导入任务
+  const handleCancelImport = async () => {
+    cancelledRef.current = true;
+    await importTaskStorage.cancelHtmlTask();
+  };
+
   // 触发文件选择
   const triggerFileInput = () => {
     fileInputRef.current?.click();
@@ -203,7 +213,10 @@ export function ImportExportPage() {
         return;
       }
 
-      if (task.progress.status === "failed") {
+      if (
+        task.progress.status === "failed" ||
+        task.progress.status === "cancelled"
+      ) {
         await importTaskStorage.clearHtmlTask();
         return;
       }
@@ -259,6 +272,7 @@ export function ImportExportPage() {
     const file = event.target.files?.[0];
     if (!file) return;
 
+    cancelledRef.current = false;
     setImporting(true);
     setImportResult(null);
 
@@ -300,6 +314,7 @@ export function ImportExportPage() {
 
   // 从浏览器导入
   const handleBrowserImport = async () => {
+    cancelledRef.current = false;
     setImporting(true);
     setImportResult(null);
 
@@ -455,11 +470,13 @@ export function ImportExportPage() {
     }
 
     if (Array.isArray(data.workspaceCategories)) {
-      const sortedWorkspaceCategories = [...data.workspaceCategories].sort((a, b) => {
-        if (a.parentId === null && b.parentId !== null) return -1;
-        if (a.parentId !== null && b.parentId === null) return 1;
-        return 0;
-      });
+      const sortedWorkspaceCategories = [...data.workspaceCategories].sort(
+        (a, b) => {
+          if (a.parentId === null && b.parentId !== null) return -1;
+          if (a.parentId !== null && b.parentId === null) return 1;
+          return 0;
+        },
+      );
       const pending = [...sortedWorkspaceCategories];
       let round = 0;
 
@@ -472,13 +489,17 @@ export function ImportExportPage() {
             ? (workspaceCategoryIdMap.get(category.parentId) ?? null)
             : null;
 
-          if (category.parentId && !workspaceCategoryIdMap.has(category.parentId)) {
+          if (
+            category.parentId &&
+            !workspaceCategoryIdMap.has(category.parentId)
+          ) {
             stillPending.push(category);
             continue;
           }
 
           const existing = allWorkspaceCategories.find(
-            (item) => item.name === category.name && item.parentId === newParentId,
+            (item) =>
+              item.name === category.name && item.parentId === newParentId,
           );
 
           if (existing) {
@@ -522,7 +543,9 @@ export function ImportExportPage() {
     }
 
     if (data.tabGroupAutoGroupSettings) {
-      await tabGroupRulesStorage.setAutoGroupSettings(data.tabGroupAutoGroupSettings);
+      await tabGroupRulesStorage.setAutoGroupSettings(
+        data.tabGroupAutoGroupSettings,
+      );
     }
 
     // 批量添加 embedding 任务（在 background 中执行）
@@ -833,6 +856,10 @@ export function ImportExportPage() {
       batchStart < task.payload.bookmarksToImport.length;
       batchStart += BATCH_SIZE
     ) {
+      // 每批次开始前检查取消信号
+      if (cancelledRef.current) {
+        break;
+      }
       batchIndex++;
       const batchLoopStart = performance.now();
       const batch = task.payload.bookmarksToImport.slice(
@@ -1031,6 +1058,29 @@ export function ImportExportPage() {
     }
 
     setImportProgress(null);
+
+    // 任务被取消时，展示已处理的进度并提前返回
+    if (cancelledRef.current) {
+      await importTaskStorage.clearHtmlTask();
+      setImportResult({
+        success: false,
+        cancelled: true,
+        message: t("settings.importExport.import.importCancelled", {
+          ns: "settings",
+        }),
+        details: buildHTMLImportDetails(
+          {
+            imported,
+            skipped,
+            duplicateSkipped,
+            categoriesCreated,
+            aiProcessed,
+          },
+          options,
+        ),
+      });
+      return;
+    }
 
     // 批量添加 embedding 任务（在 background 中执行）
     if (importedBookmarkIds.length > 0) {
@@ -1357,13 +1407,27 @@ export function ImportExportPage() {
           {/* 导入进度 */}
           {importing && importProgress && (
             <div className="mt-4 p-4 rounded-lg bg-muted">
-              <div className="flex items-center gap-3 mb-3">
-                <Loader2 className="h-5 w-5 text-primary animate-spin" />
-                <span className="text-sm font-medium">
-                  {t("settings.importExport.import.importing", {
-                    ns: "settings",
-                  })}
-                </span>
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-3">
+                  <Loader2 className="h-5 w-5 text-primary animate-spin" />
+                  <span className="text-sm font-medium">
+                    {t("settings.importExport.import.importing", {
+                      ns: "settings",
+                    })}
+                  </span>
+                </div>
+                {enableAIAnalysis && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleCancelImport}
+                    className="h-7 text-xs"
+                  >
+                    {t("settings.importExport.import.cancelImport", {
+                      ns: "settings",
+                    })}
+                  </Button>
+                )}
               </div>
               <Progress
                 value={(importProgress.current / importProgress.total) * 100}
@@ -1391,8 +1455,23 @@ export function ImportExportPage() {
             </div>
           )}
 
+          {/* 取消结果提示 */}
+          {importResult && !importResult.success && importResult.cancelled && (
+            <div className="mt-4 p-4 rounded-lg flex items-start gap-3 bg-amber-50 dark:bg-amber-950/20 text-amber-800 dark:text-amber-200">
+              <AlertCircle className="h-5 w-5 mt-0.5" />
+              <div>
+                <p className="font-medium">{importResult.message}</p>
+                {importResult.details && (
+                  <p className="text-sm opacity-80 mt-1">
+                    {importResult.details}
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+
           {/* 导入结果 */}
-          {importResult && (
+          {importResult && !importResult.cancelled && (
             <div
               className={`mt-4 p-4 rounded-lg flex items-start gap-3 ${
                 importResult.success

--- a/apps/extension/docs/build-and-release.md
+++ b/apps/extension/docs/build-and-release.md
@@ -1,0 +1,379 @@
+# HamHome 扩展打包与发布文档
+
+**版本：** 1.2.0  
+**更新日期：** 2026-06-23  
+**构建工具：** WXT 0.20+ / pnpm 9 / Turborepo 2
+
+---
+
+## 目录
+
+1. [环境要求](#1-环境要求)
+2. [项目结构](#2-项目结构)
+3. [依赖安装](#3-依赖安装)
+4. [开发调试](#4-开发调试)
+5. [生产构建](#5-生产构建)
+6. [打包 ZIP](#6-打包-zip)
+7. [产物说明](#7-产物说明)
+8. [发布到商店](#8-发布到商店)
+9. [包体积分析](#9-包体积分析)
+10. [版本管理](#10-版本管理)
+11. [常见问题](#11-常见问题)
+
+---
+
+## 1. 环境要求
+
+| 工具 | 版本要求 | 说明 |
+|------|---------|------|
+| Node.js | >= 18.0.0（推荐 18–24） | Node 25+ 可能导致 `wxt submit` 异常 |
+| pnpm | 9.x | 项目强制 `packageManager: pnpm@9.0.0` |
+| Chrome / Edge | 最新稳定版 | 用于加载未打包扩展调试 |
+| Firefox | >= 109.0 | 扩展最低支持版本 |
+
+---
+
+## 2. 项目结构
+
+```
+ham_home/
+├── apps/
+│   └── extension/          # 扩展主包（WXT）
+│       ├── entrypoints/    # 入口文件
+│       │   ├── background.ts       # Service Worker
+│       │   ├── content.ts          # Content Script
+│       │   ├── app/                # Options/主应用页
+│       │   └── popup/              # Popup 页
+│       ├── components/     # React 组件
+│       ├── hooks/          # 自定义 Hooks
+│       ├── lib/            # 核心逻辑（storage、services、agent）
+│       ├── locales/        # i18n 文案（zh / en）
+│       ├── public/         # 静态资源（图标、_locales）
+│       ├── scripts/        # 构建辅助脚本
+│       │   └── submit.js   # 多商店发布脚本
+│       ├── wxt.config.ts   # WXT 构建配置 & Manifest
+│       └── package.json
+├── packages/               # 共享库（ui、agent、utils 等）
+├── turbo.json              # Turborepo 任务依赖配置
+└── package.json            # 根工作区
+```
+
+### 入口文件说明
+
+| 文件 | 类型 | 说明 |
+|------|------|------|
+| `background.ts` | Service Worker | 快捷键、右键菜单、消息路由、定时同步 |
+| `content.ts` | Content Script | 页面内容提取、侧边面板 UI 注入 |
+| `app/` | Options Page | 主管理界面（书签、分类、设置、导入导出） |
+| `popup/` | Popup | 工具栏点击弹窗，快速保存当前页 |
+
+---
+
+## 3. 依赖安装
+
+在 **项目根目录**（`ham_home/`）执行：
+
+```bash
+pnpm install
+```
+
+Turborepo + pnpm workspace 会自动安装所有子包依赖，包括 `packages/*` 中的共享库。
+
+> **注意：** 不要在 `apps/extension/` 内单独执行 `pnpm install`，会破坏 workspace 软链。
+
+---
+
+## 4. 开发调试
+
+### 启动开发服务器
+
+```bash
+# 从根目录启动（推荐）
+pnpm dev:extension          # Chrome（默认）
+pnpm dev:ext-firefox        # Firefox
+pnpm dev:ext-edge           # Edge
+
+# 或在 apps/extension/ 目录内直接使用 wxt
+pnpm --filter hamhome dev
+pnpm --filter hamhome dev:firefox
+pnpm --filter hamhome dev:edge
+```
+
+开发服务器固定端口 **3124**，支持热重载（HMR）。
+
+### 在浏览器中加载
+
+**Chrome / Edge：**
+1. 打开 `chrome://extensions/` 或 `edge://extensions/`
+2. 开启「开发者模式」
+3. 点击「加载已解压的扩展程序」
+4. 选择 `apps/extension/.output/chrome-mv3/`（dev 模式目录）
+
+**Firefox：**
+1. 打开 `about:debugging#/runtime/this-firefox`
+2. 点击「临时载入附加组件」
+3. 选择 `apps/extension/.output/firefox-mv2/manifest.json`
+
+---
+
+## 5. 生产构建
+
+### 构建单个浏览器
+
+```bash
+# 在根目录
+pnpm build:extension        # 构建全部三个浏览器（Chrome + Firefox + Edge）
+
+# 或按需单独构建
+pnpm --filter hamhome build            # Chrome
+pnpm --filter hamhome build:firefox   # Firefox
+pnpm --filter hamhome build:edge      # Edge
+```
+
+### 构建说明
+
+- 生产构建会自动 **移除所有 `console.log` 和 `debugger`**（`wxt.config.ts` 中 esbuild `drop` 配置）
+- 共享包（`packages/*`）由 Turborepo `dependsOn: ["^build"]` 保证先于扩展完成构建
+- 构建产物输出至 `apps/extension/.output/`
+
+### 构建产物目录
+
+```
+apps/extension/.output/
+├── chrome-mv3/     # Chrome 生产构建
+├── firefox-mv2/    # Firefox 生产构建
+└── edge-mv3/       # Edge 生产构建（与 Chrome 结构相同）
+```
+
+---
+
+## 6. 打包 ZIP
+
+提交到各浏览器商店前需要将构建产物打成 ZIP 包。
+
+```bash
+# 从根目录（推荐）
+pnpm zip:extension          # 打包全部三个平台
+
+# 或按平台单独打包
+pnpm --filter hamhome zip             # Chrome
+pnpm --filter hamhome zip:firefox    # Firefox
+pnpm --filter hamhome zip:edge       # Edge
+pnpm --filter hamhome zip:all        # 全部
+```
+
+ZIP 产物输出到 `apps/extension/.output/`，命名格式：
+
+```
+hamhome-{version}-chrome.zip
+hamhome-{version}-firefox.zip
+hamhome-{version}-edge.zip
+hamhome-{version}-sources.zip    # Firefox 审核要求的源码包
+```
+
+> `version` 取自 `wxt.config.ts` 的 `manifest.version` 字段，当前为 **1.2.0**。
+
+---
+
+## 7. 产物说明
+
+### 各平台差异
+
+| 项目 | Chrome | Edge | Firefox |
+|------|--------|------|---------|
+| Manifest 版本 | V3 | V3 | V2 |
+| Background | Service Worker | Service Worker | Background Page |
+| `tabGroups` 权限 | ✅ | ✅ | ❌（已条件排除） |
+| `favicon` API | ✅ | ✅ | ❌（安全回退） |
+| `gecko` 配置 | — | — | ✅（`hamhome@example.com`） |
+| 最低版本 | 最新 | 最新 | 109.0 |
+
+### Manifest 关键配置（`wxt.config.ts`）
+
+```typescript
+version: "1.2.0"
+default_locale: "zh_CN"
+permissions: [
+  "storage", "unlimitedStorage", "activeTab", "tabs",
+  "tabGroups",   // 仅 Chromium
+  "scripting", "clipboardWrite", "contextMenus",
+  "bookmarks", "alarms", "favicon"
+]
+host_permissions: ["<all_urls>"]
+omnibox: { keyword: "ham" }
+commands: {
+  "save-bookmark":         Ctrl+Shift+X / Cmd+Shift+X
+  "save-workspace":        Ctrl+Shift+Y / Cmd+Shift+Y
+  "toggle-bookmark-panel": Ctrl+Shift+L / Cmd+Shift+L
+}
+```
+
+---
+
+## 8. 发布到商店
+
+### 8.1 配置环境变量
+
+在 `apps/extension/` 目录下创建 `.env.submit` 文件（**不要提交到 git**）：
+
+```bash
+# Chrome Web Store
+CHROME_EXTENSION_ID=your_extension_id
+CHROME_CLIENT_ID=your_client_id
+CHROME_CLIENT_SECRET=your_client_secret
+CHROME_REFRESH_TOKEN=your_refresh_token
+
+# Firefox Add-ons (AMO)
+FIREFOX_EXTENSION_ID=hamhome@example.com
+FIREFOX_JWT_ISSUER=your_jwt_issuer
+FIREFOX_JWT_SECRET=your_jwt_secret
+
+# Microsoft Edge Add-ons
+EDGE_PRODUCT_ID=your_product_id
+EDGE_CLIENT_ID=your_client_id
+EDGE_API_KEY=your_api_key
+```
+
+只需配置目标商店的变量，未配置的商店会被自动跳过。
+
+### 8.2 一键发布
+
+```bash
+# 从根目录
+pnpm submit:extension       # 自动执行：zip:all → 读取 .env.submit → wxt submit
+
+# 跳过重新打包（使用已有 ZIP）
+pnpm --filter hamhome submit:all -- --skip-zip
+```
+
+发布脚本（`scripts/submit.js`）执行逻辑：
+1. 调用 `pnpm zip:all` 生成最新 ZIP（除非传入 `--skip-zip`）
+2. 从 `wxt.config.ts` 读取版本号
+3. 根据 `.env.submit` 中配置的环境变量，确定需要发布的商店
+4. 构建 `wxt submit` 参数并执行
+
+### 8.3 初始化提交配置
+
+首次发布前需要初始化：
+
+```bash
+pnpm submit:init
+# 或
+pnpm --filter hamhome submit:init
+```
+
+### 8.4 Firefox 源码包
+
+Firefox AMO 审核要求提交源码包（`.output/hamhome-{version}-sources.zip`），`zip:all` 命令会自动生成。
+
+---
+
+## 9. 包体积分析
+
+构建时传入 `ANALYZE=true` 环境变量，可生成可视化体积报告（`stats.html`，自动在浏览器打开）：
+
+**Windows（PowerShell）：**
+```powershell
+$env:ANALYZE="true"; pnpm --filter hamhome build
+```
+
+**macOS / Linux：**
+```bash
+ANALYZE=true pnpm --filter hamhome build
+```
+
+或使用 `package.json` 中预置的 `analyze` 脚本：
+```bash
+pnpm --filter hamhome analyze
+```
+
+报告包含 gzip 和 brotli 两种压缩尺寸，由 `rollup-plugin-visualizer` 生成。
+
+---
+
+## 10. 版本管理
+
+**版本号只在一处维护：**
+
+```typescript
+// apps/extension/wxt.config.ts
+manifest: () => ({
+  version: "1.2.0",   // ← 修改此处
+  ...
+})
+```
+
+发布脚本和 ZIP 命名均从此处自动读取，无需同步修改其他文件。
+
+### 升版本步骤
+
+1. 修改 `apps/extension/wxt.config.ts` 中的 `version`
+2. 同步修改 `apps/extension/package.json` 中的 `version`（保持一致，便于维护）
+3. 执行 `pnpm zip:extension` 生成新版 ZIP
+4. 执行 `pnpm submit:extension` 发布
+
+---
+
+## 11. 常见问题
+
+### Q：构建失败，提示找不到共享包
+
+```
+Cannot resolve '@hamhome/ui'
+```
+
+**原因：** `packages/*` 共享库未构建。  
+**解决：** 先在根目录执行 `pnpm build`（Turborepo 会自动处理依赖顺序），或单独执行：
+
+```bash
+pnpm --filter @hamhome/ui build
+pnpm --filter @hamhome/agent build
+```
+
+---
+
+### Q：`wxt submit` 报错 Node.js 版本兼容问题
+
+**原因：** Node.js >= 25 与 `wxt submit` 的上游依赖存在已知兼容问题。  
+**解决：** 切换到 Node 18–24，推荐使用 nvm：
+
+```bash
+nvm use 20
+```
+
+---
+
+### Q：Firefox 构建缺少 `tabGroups` 但报错
+
+**说明：** `wxt.config.ts` 中已通过 `browser !== "firefox"` 条件排除此权限，Firefox 构建不会包含它，属于正常行为。
+
+---
+
+### Q：开发模式热重载不生效
+
+**解决：**
+1. 确认开发服务器端口 3124 未被占用
+2. 在浏览器扩展管理页面点击「刷新」扩展
+3. 若 content script 修改未生效，刷新目标网页
+
+---
+
+### Q：打包后扩展体积过大
+
+**排查：**
+1. 运行 `pnpm --filter hamhome analyze` 查看体积分布
+2. 检查是否有不必要的依赖被打入扩展包
+3. 生产构建已自动移除 `console.log`（esbuild `drop` 配置）
+
+---
+
+### Q：如何清理所有构建产物
+
+```bash
+# 清理全部（含 node_modules）
+pnpm clean
+
+# 仅清理扩展构建产物
+pnpm --filter hamhome clean
+# 等价于：rm -rf apps/extension/.wxt apps/extension/.output apps/extension/dist
+```

--- a/apps/extension/docs/import-ai-analysis-report.md
+++ b/apps/extension/docs/import-ai-analysis-report.md
@@ -1,0 +1,198 @@
+# 导入 AI 自动分类打标逻辑分析报告
+
+**分析文件：** `apps/extension/components/ImportExportPage.tsx`  
+**日期：** 2026-06-23  
+
+---
+
+## 一、整体流程图
+
+```
+用户操作
+  │
+  ├─ 勾选 enableAIAnalysis (Checkbox L1244)
+  │
+  ├─ 点击"从文件导入"或"从浏览器导入"
+  │         │
+  │         ▼
+  │  handleFileImport / handleBrowserImport
+  │    setImporting(true)  ← 开关置 ON (L262 / L303)
+  │    pauseWatchers()
+  │         │
+  │         ▼
+  │  importFromHTML(content, source)
+  │    collectHTMLBookmarks()   ← 解析 HTML，收集书签列表
+  │    importTaskStorage.createHtmlTask()  ← 持久化任务到 localStorage
+  │         │
+  │         ▼
+  │  runHtmlImportTask(task)
+  │    for each BATCH:
+  │      if (enableAIAnalysis):
+  │        for each bookmark:  ← 串行逐条调用 AI
+  │          analyzeBookmarkWithAI()
+  │            bookmarkAnalysisService.analyzeBookmarkForLibrary()
+  │              → LLM API 请求（无中断机制）
+  │    setImporting(false)  ← 开关置 OFF (L293 / L329)
+  │    importTaskStorage.clearHtmlTask()
+```
+
+---
+
+## 二、开关的开启和关闭逻辑
+
+### 2.1 开启（`importing = true`）
+
+| 触发点 | 代码位置 |
+|--------|---------|
+| 文件导入 `handleFileImport` | L262 `setImporting(true)` |
+| 浏览器书签导入 `handleBrowserImport` | L303 `setImporting(true)` |
+| 页面重载后恢复未完成任务 `resumePendingTask` | L220 `setImporting(true)` |
+
+### 2.2 关闭（`importing = false`）
+
+| 触发点 | 代码位置 |
+|--------|---------|
+| `handleFileImport` 的 `finally` | L293 `setImporting(false)` |
+| `handleBrowserImport` 的 `finally` | L328 `setImporting(false)` |
+| `resumePendingTask` 的 `finally` | L248 `setImporting(false)` |
+
+**关键问题：** 只有上述三条路径才能把 `importing` 改为 `false`，且全部位于 `finally` 块中——**必须等待整个导入任务自然结束或抛出异常才会触发**，没有任何"手动取消"的分支。
+
+---
+
+## 三、AI 分析的具体执行流程
+
+```
+runHtmlImportTask (L762)
+  ├── BATCH_SIZE = MAX_IMPORT_CONCURRENCY (5) 当启用 AI 时
+  ├── for batchStart = currentIndex → total, step BATCH_SIZE
+  │     ├── if enableAIAnalysis && !preserveFolders:
+  │     │     for bm in batch:          ← 串行（不是并发）
+  │     │       analyzeBookmarkWithAI(bm.url, bm.title, ...)
+  │     │         └── bookmarkAnalysisService.analyzeBookmarkForLibrary()
+  │     │               └── LLM API 请求（await，无 AbortController）
+  │     ├── createBookmarks(readyItems)
+  │     └── persistProgress()           ← 定期写入 localStorage
+  └── clearHtmlTask()
+```
+
+**重要特征：**
+- AI 分析是**串行**的（逐条 `await analyzeBookmarkWithAI`），不是并发
+- 每条 AI 调用**没有超时控制**
+- 整个 `for` 循环**没有中断信号**（无 `AbortController`、无取消 flag）
+- `persistProgress()` 保证了进度持久化，页面刷新后可**自动恢复**
+
+---
+
+## 四、UI 层的控制与缺陷
+
+### 导入中的 UI 状态（L1304–1355）
+
+```tsx
+{/* 两个导入按钮，importing=true 时 disabled */}
+<button onClick={triggerFileInput} disabled={importing} ...>
+<button onClick={handleBrowserImport} disabled={importing} ...>
+```
+
+**进度条区域（L1358–1392）：**
+```tsx
+{importing && importProgress && (
+  <div>
+    <Loader2 ... animate-spin />
+    <Progress value={...} />
+    <p>已处理 {current} / {total}</p>
+    {/* ❌ 没有取消按钮 */}
+  </div>
+)}
+```
+
+### 存在的问题总结
+
+| 问题 | 说明 |
+|------|------|
+| **无取消按钮** | 进度区域只有 Loading 动画和进度条，没有"停止"按钮 |
+| **无取消信号** | `runHtmlImportTask` 内部没有 `AbortController` 或 cancel flag |
+| **AI 调用不可中断** | `bookmarkAnalysisService.analyzeBookmarkForLibrary` 是普通 `await`，无法提前终止 |
+| **导入按钮被禁用** | `disabled={importing}` 让用户无法重新操作，却又没有取消出口 |
+| **任务自动恢复** | 页面刷新后 `resumePendingTask` 会自动续跑，无法通过刷新页面中止 |
+
+---
+
+## 五、对比：`useBatchAITask` 的取消实现（可参考）
+
+`useBatchAITask.ts` 对批量 AI 任务**有取消机制**：
+
+```typescript
+// useBatchAITask.ts L32-35
+const currentTask = await aiTaskStorage.getTask();
+if (!currentTask || currentTask.progress.status === 'failed') {
+  break; // 检测到任务被清除则退出循环
+}
+
+// L154-158
+const cancelTask = async () => {
+  await aiTaskStorage.clearTask();   // 清除存储中的任务 → 让循环 break
+  setProgress(null);
+  setIsProcessing(false);
+};
+```
+
+**取消原理：** 每个批次开始前读取存储，如果任务已被清除（`clearTask()`），循环立即 `break`。
+
+`ImportExportPage` 的 `runHtmlImportTask` **缺少这个检查**。
+
+---
+
+## 六、修复方案设计
+
+### 方案 A：轻量 Flag（最小改动）
+
+1. 在 `ImportTaskStorage` 增加 `cancelled` 状态字段  
+   或在组件内用 `useRef<boolean>` 存取消标志
+
+2. 在 `runHtmlImportTask` 的批次循环开始处检查：
+   ```typescript
+   // 每个 batch 开始前检查
+   const task = await importTaskStorage.getHtmlTask();
+   if (!task || cancelledRef.current) {
+     break;
+   }
+   ```
+
+3. 在进度区域添加取消按钮：
+   ```tsx
+   <Button onClick={handleCancelImport} variant="outline" size="sm">
+     停止导入
+   </Button>
+   ```
+
+4. `handleCancelImport` 实现：
+   ```typescript
+   const handleCancelImport = async () => {
+     cancelledRef.current = true;
+     await importTaskStorage.clearHtmlTask();
+   };
+   ```
+
+### 方案 B：状态字段扩展（更健壮）
+
+在 `HtmlImportTaskProgress` 中增加 `status: 'running' | 'cancelled' | 'failed'`，并在存储层提供 `cancelHtmlTask()` 方法。循环内每批检查 `status === 'cancelled'` 后 `break`。
+
+**推荐方案 A 作为快速修复**，方案 B 作为后续重构。
+
+---
+
+## 七、需要修改的文件清单
+
+| 文件 | 改动内容 |
+|------|---------|
+| `components/ImportExportPage.tsx` | 增加 `cancelledRef`；在 `runHtmlImportTask` 批次循环内加取消检查；进度区域增加取消按钮；添加 `handleCancelImport` 函数 |
+| `lib/storage/import-task-storage.ts` | （方案B）增加 `cancelHtmlTask()` 方法，将 status 设为 `cancelled` |
+
+---
+
+## 八、影响范围
+
+- `importFromHTML` → `runHtmlImportTask`：仅 HTML 格式导入受影响（文件 `.html/.htm` 和浏览器书签）
+- JSON 格式导入 (`importFromJSON`) 不使用 AI 分析，无此问题
+- 页面刷新恢复逻辑 (`resumePendingTask`) 需同步判断 `cancelled` 状态，避免已取消的任务被重新续跑

--- a/apps/extension/docs/import-cancel-fix-report.md
+++ b/apps/extension/docs/import-cancel-fix-report.md
@@ -1,0 +1,204 @@
+# 修复报告：导入 AI 分类打标无法手动停止
+
+**修复日期：** 2026-06-23  
+**严重等级：** 中（数据量大时用户无法中断，体验阻塞）
+
+---
+
+## 问题描述
+
+导入 HTML 书签并勾选「使用 AI 自动分类打标」后，点击开始导入即进入无法退出的锁定状态：
+
+- 导入按钮被 `disabled`，无法重新操作
+- 进度区域没有停止按钮
+- 刷新页面会被 `resumePendingTask` 自动续跑
+- AI 调用串行执行且无中断机制，数千条书签需等待数小时
+
+---
+
+## 根本原因
+
+`runHtmlImportTask`（`ImportExportPage.tsx` L762）的批次 `for` 循环内部没有任何取消检查点，`analyzeBookmarkWithAI` 是普通 `await`，整个任务只能等自然结束或异常才会退出。
+
+---
+
+## 修复方案
+
+采用「**组件内 `useRef` cancel flag + 存储层 `cancelled` 状态**」的轻量方案：
+
+```
+cancelledRef (useRef<boolean>)
+       │ handleCancelImport() 置 true
+       │ importTaskStorage.cancelHtmlTask() 写入 localStorage
+       ▼
+runHtmlImportTask 每批次开头检查 cancelledRef.current
+       │ true → break，设置「已停止」结果，提前 return
+       ▼
+resumePendingTask 检查 status === 'cancelled'
+       │ → clearHtmlTask()，不再续跑
+```
+
+---
+
+## 变更文件清单
+
+### 1. `lib/storage/import-task-storage.ts`
+
+| 变更 | 说明 |
+|------|------|
+| `HtmlImportTaskProgress.status` 新增 `'cancelled'` | 持久化取消状态，防止刷新后续跑 |
+| 新增 `cancelHtmlTask()` 方法 | 将进度状态写为 `cancelled`，供 `handleCancelImport` 调用 |
+
+```diff
+- status: 'running' | 'failed';
++ status: 'running' | 'failed' | 'cancelled';
+
++ async cancelHtmlTask(): Promise<void> {
++   await this.updateHtmlProgress((progress) => ({
++     ...progress,
++     status: 'cancelled',
++   }));
++ }
+```
+
+---
+
+### 2. `components/ImportExportPage.tsx`
+
+#### ① 新增 `cancelledRef`（L72）
+
+```typescript
+const cancelledRef = useRef(false);
+```
+
+#### ② 每次新导入前重置 flag（L267, L309）
+
+```typescript
+// handleFileImport
+cancelledRef.current = false;
+setImporting(true);
+
+// handleBrowserImport
+cancelledRef.current = false;
+setImporting(true);
+```
+
+#### ③ 新增 `handleCancelImport` 函数（L192）
+
+```typescript
+const handleCancelImport = async () => {
+  cancelledRef.current = true;
+  await importTaskStorage.cancelHtmlTask();
+};
+```
+
+#### ④ `runHtmlImportTask` 批次循环加取消检查（L843）
+
+```typescript
+for (let batchStart = currentIndex; ...) {
++ // 每批次开始前检查取消信号
++ if (cancelledRef.current) {
++   break;
++ }
+  batchIndex++;
+  ...
+}
+```
+
+#### ⑤ 循环结束后处理取消状态（L1058）
+
+```typescript
+setImportProgress(null);
+
++ if (cancelledRef.current) {
++   await importTaskStorage.clearHtmlTask();
++   setImportResult({
++     success: false,
++     cancelled: true,
++     message: t("settings.importExport.import.importCancelled", { ns: "settings" }),
++     details: buildHTMLImportDetails(...),  // 展示已处理数量
++   });
++   return;
++ }
+```
+
+#### ⑥ `resumePendingTask` 处理 `cancelled` 状态（L212）
+
+```typescript
+- if (task.progress.status === "failed") {
++ if (task.progress.status === "failed" || task.progress.status === "cancelled") {
+    await importTaskStorage.clearHtmlTask();
+    return;
+  }
+```
+
+#### ⑦ 进度区域加「停止导入」按钮（JSX L1371）
+
+仅在 `enableAIAnalysis === true` 时显示，避免对普通导入造成干扰：
+
+```tsx
+{enableAIAnalysis && (
+  <Button variant="outline" size="sm" onClick={handleCancelImport} className="h-7 text-xs">
+    {t("settings.importExport.import.cancelImport", { ns: "settings" })}
+  </Button>
+)}
+```
+
+#### ⑧ 进度区域布局调整
+
+进度头部从 `flex items-center gap-3` 改为 `flex items-center justify-between`，让停止按钮靠右对齐。
+
+#### ⑨ `importResult` 类型加 `cancelled?: boolean` 字段
+
+取消结果用琥珀色（`bg-amber-50`）区别于红色失败提示，正常失败/成功结果通过 `!importResult.cancelled` 过滤。
+
+#### ⑩ 从 `@hamhome/ui` import 中补充 `Button`
+
+```diff
+ import {
++  Button,
+   Card,
+   ...
+ } from "@hamhome/ui";
+```
+
+---
+
+### 3. `locales/zh/settings.json`
+
+```diff
+  "browserBookmarkCount": "浏览器中共有 {{count}} 个书签",
++ "cancelImport": "停止导入",
++ "importCancelled": "导入已停止"
+```
+
+### 4. `locales/en/settings.json`
+
+```diff
+  "browserBookmarkCount": "Total {{count}} bookmarks in browser",
++ "cancelImport": "Stop Import",
++ "importCancelled": "Import stopped"
+```
+
+---
+
+## 行为变化对比
+
+| 场景 | 修复前 | 修复后 |
+|------|--------|--------|
+| AI 导入进行中 | 只有转圈动画，无法操作 | 进度条右侧显示「停止导入」按钮 |
+| 点击停止 | — | 当前 AI 调用完成后（≤1条）即停止，不再处理后续书签 |
+| 停止后显示 | — | 琥珀色提示框，显示已导入数量 |
+| 刷新页面（导入中） | 自动续跑未完成任务 | `cancelled` 状态被识别，清除任务，不再续跑 |
+| 普通导入（不含 AI） | 无取消按钮 | 无变化（停止按钮仅在 AI 模式下显示） |
+| 已导入的书签 | — | 停止前已写入的书签保留，数据不丢失 |
+
+> **注意：** 停止信号在每个 **批次** 开始前生效（AI 模式下批次大小为 5），最多会多处理完当前批次内剩余的书签（<5条）。单条 AI 请求发出后无法中断（这是 `await` 的固有限制），但最多等待一个请求完成即可停下。
+
+---
+
+## 未涉及范围（有意不改）
+
+- `importFromJSON`：不使用 AI，无需取消
+- `useBatchAITask`：已有独立 `cancelTask`，不受影响
+- `analyzeBookmarkWithAI` 内部未加 `AbortController`：本次最小改动不涉及，如需进一步缩短等待时间可后续优化

--- a/apps/extension/lib/storage/import-task-storage.ts
+++ b/apps/extension/lib/storage/import-task-storage.ts
@@ -1,4 +1,4 @@
-import { nanoid } from 'nanoid';
+import { nanoid } from "nanoid";
 
 export interface ImportTaskOptions {
   preserveFolders: boolean;
@@ -14,7 +14,7 @@ export interface BookmarkToImport {
 
 export interface HtmlImportTaskPayload {
   id: string;
-  source: 'file' | 'browser';
+  source: "file" | "browser";
   options: ImportTaskOptions;
   bookmarksToImport: BookmarkToImport[];
   total: number;
@@ -23,7 +23,7 @@ export interface HtmlImportTaskPayload {
 
 export interface HtmlImportTaskProgress {
   taskId: string;
-  status: 'running' | 'failed';
+  status: "running" | "failed" | "cancelled";
   currentIndex: number;
   imported: number;
   skipped: number;
@@ -41,17 +41,25 @@ export interface HtmlImportTask {
   progress: HtmlImportTaskProgress;
 }
 
-const htmlImportTaskPayloadItem = storage.defineItem<HtmlImportTaskPayload | null>('local:htmlImportTaskPayload', {
-  fallback: null,
-});
+const htmlImportTaskPayloadItem =
+  storage.defineItem<HtmlImportTaskPayload | null>(
+    "local:htmlImportTaskPayload",
+    {
+      fallback: null,
+    },
+  );
 
-const htmlImportTaskProgressItem = storage.defineItem<HtmlImportTaskProgress | null>('local:htmlImportTaskProgress', {
-  fallback: null,
-});
+const htmlImportTaskProgressItem =
+  storage.defineItem<HtmlImportTaskProgress | null>(
+    "local:htmlImportTaskProgress",
+    {
+      fallback: null,
+    },
+  );
 
 class ImportTaskStorage {
   async createHtmlTask(input: {
-    source: 'file' | 'browser';
+    source: "file" | "browser";
     options: ImportTaskOptions;
     bookmarksToImport: BookmarkToImport[];
     categoriesCreated: number;
@@ -70,7 +78,7 @@ class ImportTaskStorage {
 
     const progress: HtmlImportTaskProgress = {
       taskId: id,
-      status: 'running',
+      status: "running",
       currentIndex: 0,
       imported: 0,
       skipped: 0,
@@ -108,7 +116,7 @@ class ImportTaskStorage {
   }
 
   async updateHtmlProgress(
-    updater: (progress: HtmlImportTaskProgress) => HtmlImportTaskProgress
+    updater: (progress: HtmlImportTaskProgress) => HtmlImportTaskProgress,
   ): Promise<HtmlImportTaskProgress | null> {
     const progress = await htmlImportTaskProgressItem.getValue();
     if (!progress) return null;
@@ -122,10 +130,17 @@ class ImportTaskStorage {
     return updated;
   }
 
+  async cancelHtmlTask(): Promise<void> {
+    await this.updateHtmlProgress((progress) => ({
+      ...progress,
+      status: "cancelled",
+    }));
+  }
+
   async markHtmlTaskFailed(error: string): Promise<void> {
     await this.updateHtmlProgress((progress) => ({
       ...progress,
-      status: 'failed',
+      status: "failed",
       error,
     }));
   }

--- a/apps/extension/locales/en/settings.json
+++ b/apps/extension/locales/en/settings.json
@@ -323,7 +323,9 @@
         "fetchPageContentDesc": "Access bookmark URLs to get page content for more accurate AI analysis (slower)",
         "fromBrowser": "Import from Browser",
         "fromBrowserDesc": "Directly read bookmarks from current browser",
-        "browserBookmarkCount": "Total {{count}} bookmarks in browser"
+        "browserBookmarkCount": "Total {{count}} bookmarks in browser",
+        "cancelImport": "Stop Import",
+        "importCancelled": "Import stopped"
       },
       "syncBrowser": {
         "title": "Sync to Browser Bookmarks",

--- a/apps/extension/locales/zh/settings.json
+++ b/apps/extension/locales/zh/settings.json
@@ -323,7 +323,9 @@
         "fetchPageContentDesc": "访问书签 URL 获取页面内容以获得更准确的 AI 分析结果（较慢）",
         "fromBrowser": "从浏览器导入",
         "fromBrowserDesc": "直接读取当前浏览器的书签数据",
-        "browserBookmarkCount": "浏览器中共有 {{count}} 个书签"
+        "browserBookmarkCount": "浏览器中共有 {{count}} 个书签",
+        "cancelImport": "停止导入",
+        "importCancelled": "导入已停止"
       },
       "syncBrowser": {
         "title": "同步到浏览器书签栏",


### PR DESCRIPTION
变更：
添加了开始导入标签且需要ai打标开始导入后的停止导入按钮，添加了ai生成的修改报告、打包文档等；

测试环境：
在Windows 11 企业版 LTS chrome 138.0.7204.97（正式版本） （64 位）上测试通过

结论：
导入时，点击停止导入会等待当前批次处理完后停止导入，基本符合需求

添加的停止导入的按钮：
<img width="1153" height="731" alt="image" src="https://github.com/user-attachments/assets/41e1c1dc-3890-40e4-a47f-568c7d7ec65b" />
测试验证结果：
<img width="1111" height="703" alt="image" src="https://github.com/user-attachments/assets/35d40879-e54e-45ff-824d-e927ce83c616" />
